### PR TITLE
WIP s/M/EEG forward solutions

### DIFF
--- a/main_surface.sh
+++ b/main_surface.sh
@@ -204,7 +204,7 @@ then
         mrconvert $PRD/data/DWI/ $PRD/connectivity/dwi_2.nii.gz
         mrinfo $PRD/data/DWI/ -export_grad_fsl $PRD/connectivity/bvecs_2 $PRD/connectivity/bvals_2
         mrconvert $PRD/connectivity/dwi_1.nii.gz $PRD/connectivity/dwi_1.mif -fslgrad $PRD/connectivity/bvecs_1 $PRD/connectivity/bvals_1
-        mrconvert $PRD/connectivity/dwi.nii.gz $PRD/connectivity/dwi_2.mif -fslgrad $PRD/connectivity/bvecs_2 $PRD/connectivity/bvals_2
+        mrconvert $PRD/connectivity/dwi_2.nii.gz $PRD/connectivity/dwi_2.mif -fslgrad $PRD/connectivity/bvecs_2 $PRD/connectivity/bvals_2
     fi
     if [ ! -f $PRD/connectivity/dwi.mif ]
     then

--- a/main_surface.sh
+++ b/main_surface.sh
@@ -480,3 +480,4 @@ then
     done
 fi
 
+# Calculate forward solutions with OpenMEEG

--- a/main_surface.sh
+++ b/main_surface.sh
@@ -204,7 +204,7 @@ then
         mrconvert $PRD/data/DWI/ $PRD/connectivity/dwi_2.nii.gz
         mrinfo $PRD/data/DWI/ -export_grad_fsl $PRD/connectivity/bvecs_2 $PRD/connectivity/bvals_2
         mrconvert $PRD/connectivity/dwi_1.nii.gz $PRD/connectivity/dwi_1.mif -fslgrad $PRD/connectivity/bvecs_1 $PRD/connectivity/bvals_1
-        mrconvert $PRD/connectivity/dwi_2.nii.gz $PRD/connectivity/dwi_2.mif -fslgrad $PRD/connectivity/bvecs_2 $PRD/connectivity/bvals_2
+        mrconvert $PRD/connectivity/dwi.nii.gz $PRD/connectivity/dwi_2.mif -fslgrad $PRD/connectivity/bvecs_2 $PRD/connectivity/bvals_2
     fi
     if [ ! -f $PRD/connectivity/dwi.mif ]
     then


### PR DESCRIPTION
This is a work in progress (WIP) on #26. I'll update the checklist as I go.
- 4D 248 MEG
- 10-20 EEG
- sEEG or ECoG defaults?
- [ ] dipole or surface file for the cortical surface sources (produced by FreeSurfer & scripts)
- [ ] squid file for MEG sensors (4D 248 by default, or provided by user)
- [ ] elec file for EEG sensors (10-20 by default, or provided by user)
- [ ] internal potential locations for sEEG if provided
- [ ] ECoG positions if provided
- [x] three BEM surfaces: outer skin, outer skull, inner skull (produced by mne_watershed_bem)
- [x] geometry description (autogenerate/template)
- [x] conductivities (defaults or provided by user)
- [ ] visual verification of BEM surfaces, cortex & sensors (check step, requires pyqtgraph or freeview..)
- [x] sequence of calls to OpenMEEG commands `om_*`
- [x] convert sensors & lead fields to TVB format (Python script)

Did I forget anything?

sEEG sensors are localized on a CT, which needs to be registered with FreeSurfer's T1. There we need the vox2ras-tkr xfm for the CT to obtain positions valid for the cortical and BEM surfaces.
